### PR TITLE
Add curly braces block snippet

### DIFF
--- a/snippets/language-ruby.cson
+++ b/snippets/language-ruby.cson
@@ -141,6 +141,9 @@
   'Insert do |variable| … end':
     'prefix': 'do'
     'body': 'do${1: |${2:variable}|}\n\t$0\nend'
+  'Insert curly braces block':
+    'prefix': '{'
+    'body': '{ ${1:|${2:variable}| }$0 '
   'each { |e| .. }':
     'prefix': 'ea'
     'body': 'each { |${1:e}| $0 }'


### PR DESCRIPTION
This adds a snippet that behaves like the "Insert do |variable| … end" snippet, but adds a block with curly braces syntax. It works in combination with the bracket-matcher package that autocompletes the closing curly brace.
